### PR TITLE
Add "也稱為" to sentence classification to identify links

### DIFF
--- a/sementic.py
+++ b/sementic.py
@@ -97,6 +97,8 @@ def classify_sentence(s):
     3
     >>> classify_sentence(u"俗稱為「沙丁魚。」")
     3
+    >>> classify_sentence(u"也稱為「捺」、「磔」。")
+    3
 
 
     # known incorrect
@@ -109,7 +111,7 @@ def classify_sentence(s):
     if re.match(ur'^如：「(.+)」', s):
         return 1
 
-    if re.match(ur'^(同|亦作|亦稱為|俗稱為|或作|亦作|通|或稱為|簡稱為|或譯作|縮稱為)「(.+?)(」。|。」)', s):
+    if re.match(ur'^(同|亦作|亦稱為|俗稱為|或作|亦作|通|或稱為|簡稱為|或譯作|縮稱為|也稱為)「(.+?)(」。|。」)', s):
         return 3
 
     if re.match(ur'見「(.+?)」等?條。', s):


### PR DESCRIPTION
The phrase "也稱為" is found to be the prefix of link sentences in
some of the definitions.  For instance, in the 4th noun definition of
the word "波", the last sentence is "也稱為「捺」、「磔」。" and
should be classified as a link.