### PR TITLE
feat: preserve Taiwanese heteronym IDs in xref sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ parse.log
 *.swo
 *~
 
+# Local feature worktrees
+.worktrees/
+
 # Bun/TS
 node_modules/
 coverage/

--- a/LemmaScript-files.txt
+++ b/LemmaScript-files.txt
@@ -5,5 +5,6 @@ src/pack/autolink.ts
 src/pack/special.ts
 src/pack/pipeline.ts
 src/pack/variants.ts
+src/pack/xref.ts
 src/process.ts
 src/excel.ts

--- a/docs/pack-format-contract.md
+++ b/docs/pack-format-contract.md
@@ -37,6 +37,12 @@ Each directory contains its source-defined subset of:
 - `xref.json` — cross-language mapping, shipped for Mandarin, Taiwanese, and
   Hakka. The pack generates it from optional explicit correspondence side inputs
   (`x-華語對照表.csv` and `work-in-progress.json`), not dictionary entries.
+- `xref-by-id.json` — Taiwanese-only ID-aware sidecar generated from the same
+  `x-華語對照表.csv` rows as `xref.json`. Its `a` section maps each Taiwanese
+  title to heteronym-ID groups of Mandarin words:
+  `Record<string, Record<string, string[]>>`. Identity rows contain the explicit
+  Mandarin word. The legacy `xref.json` comma encoding remains unchanged for
+  deployed consumers.
 - `=<category>.json` — Mandarin category list files.
 - `@<radical>.json` — Mandarin radical list files.
 

--- a/docs/superpowers/plans/2026-07-11-definition-source-invariants.md
+++ b/docs/superpowers/plans/2026-07-11-definition-source-invariants.md
@@ -1,0 +1,378 @@
+# Definition Source Invariants Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the legacy/modern definition-source mapping with LemmaScript and make `parseHeteronym` exclusively consume that mapping so modern 多音參見 column 16 cannot become definitions.
+
+**Architecture:** Add a verified, allocation-free `definitionSourceColumn(rowLength, source)` selector to the already verified Excel module. Remove definition and notes indices from the general `ColumnMap`; `parseHeteronym` routes its primary and optional editorial inputs only through the selector. LemmaScript proves the selector mapping, focused tests prove parser consumption, and a before/after full-workbook semantic diff characterizes all changed entries.
+
+**Tech Stack:** Bun 1.3+, TypeScript 5.7, `bun:test`, SheetJS, LemmaScript 0.5.13 with Dafny backend.
+
+## Global Constraints
+
+- Modern rows (`rowLength >= 18`) select column 15 for primary definitions and `-1` for the absent editorial source.
+- Legacy rows (`rowLength < 18`) select column 10 for primary definitions and column 11 for editorial notes.
+- Modern column 16 must never be selected as a definition source.
+- The selector parameter is `source: number` with a LemmaScript precondition, not the unsupported numeric-literal union `0 | 1`.
+- The selector allocates no arrays, objects, tags, or provenance records.
+- Do not add marker-shaped output filters.
+- Preserve legacy editorial-note behavior.
+- Treat `parseHeteronym`, regex parsing, SheetJS decoding, and object assembly as tested trust boundaries; do not claim LemmaScript verifies them.
+- Skip project-wide formatter, lint, and test commands until the final verification phase.
+
+---
+
+### Task 1: Verified definition-source selector
+
+**Files:**
+- Modify: `src/excel.ts:7-14`
+- Modify: `tests/excel.test.ts:1-83`
+
+**Interfaces:**
+- Consumes: `rowLength: number`, where `rowLength >= 0`; `source: number`, where `source === 0 || source === 1`.
+- Produces: `export function definitionSourceColumn(rowLength: number, source: number): number`.
+- Contract: modern rows map slots to `15, -1`; legacy rows map slots to `10, 11`; modern rows never return `16`.
+
+- [ ] **Step 1: Add failing selector tests**
+
+Change the import in `tests/excel.test.ts` and add the following block after `cellTypeToCtype` tests:
+
+```ts
+import {
+  cellTypeToCtype,
+  definitionSourceColumn,
+  iterateSheetRows,
+} from '../src/excel';
+
+// ...existing tests...
+
+describe('definitionSourceColumn', () => {
+  it('routes modern rows only to definitions column 15', () => {
+    expect(definitionSourceColumn(18, 0)).toBe(15);
+    expect(definitionSourceColumn(18, 1)).toBe(-1);
+    expect(definitionSourceColumn(20, 0)).toBe(15);
+    expect(definitionSourceColumn(20, 1)).toBe(-1);
+  });
+
+  it('routes legacy rows to definitions column 10 and editorial column 11', () => {
+    expect(definitionSourceColumn(14, 0)).toBe(10);
+    expect(definitionSourceColumn(14, 1)).toBe(11);
+    expect(definitionSourceColumn(17, 0)).toBe(10);
+    expect(definitionSourceColumn(17, 1)).toBe(11);
+  });
+});
+```
+
+- [ ] **Step 2: Run the selector tests and confirm the red state**
+
+Run:
+
+```bash
+bun test tests/excel.test.ts
+```
+
+Expected: FAIL because `definitionSourceColumn` is not exported by `src/excel.ts`.
+
+- [ ] **Step 3: Implement the verified selector**
+
+Add immediately after `cellTypeToCtype` in `src/excel.ts`:
+
+```ts
+/** Select a definition-bearing source column: 0=primary, 1=legacy editorial notes. */
+export function definitionSourceColumn(rowLength: number, source: number): number {
+  //@ verify
+  //@ requires rowLength >= 0
+  //@ requires source === 0 || source === 1
+  //@ ensures (rowLength >= 18 && source === 0) ==> \result === 15
+  //@ ensures (rowLength >= 18 && source === 1) ==> \result === -1
+  //@ ensures (rowLength < 18 && source === 0) ==> \result === 10
+  //@ ensures (rowLength < 18 && source === 1) ==> \result === 11
+  //@ ensures rowLength >= 18 ==> \result !== 16
+  if (source === 0) return rowLength >= 18 ? 15 : 10;
+  return rowLength >= 18 ? -1 : 11;
+}
+```
+
+- [ ] **Step 4: Run focused runtime and formal verification**
+
+Run:
+
+```bash
+bun test tests/excel.test.ts
+bun run verify
+```
+
+Expected: Excel tests PASS; LemmaScript/Dafny exits 0 and proves `definitionSourceColumn` without type-lowering errors.
+
+- [ ] **Step 5: Commit the verified selector**
+
+```bash
+git add src/excel.ts tests/excel.test.ts
+git commit -m "feat: verify definition source columns"
+```
+
+---
+
+### Task 2: Route parser definitions exclusively through the selector
+
+**Files:**
+- Modify: `src/types.ts:38-50`
+- Modify: `src/parse.ts:160-249`
+- Modify: `tests/parse.test.ts:1-414`
+
+**Interfaces:**
+- Consumes: `definitionSourceColumn(rowLength, 0 | 1)` from Task 1; the runtime calls use numeric constants, while the function signature remains `source: number`.
+- Produces: `parseHeteronym(cells)` where modern definitions originate only from column 15 and legacy definitions originate from columns 10 and 11.
+- Removes: `ColumnMap.definitions` and `ColumnMap.notes`.
+
+- [ ] **Step 1: Replace the incorrect modern-notes test with failing boundary tests**
+
+Refactor the local modern fixture so definition metadata is not represented as `keyof ColumnMap`:
+
+```ts
+type ModernRowOverrides = Partial<Record<keyof import('../src/types').ColumnMap, unknown>> & {
+  definitions?: unknown;
+  crossReference?: unknown;
+};
+
+function modernRow(overrides: ModernRowOverrides = {}): SourceCell[] {
+  const row: SourceCell[] = new Array(20).fill(null).map(() => empty());
+  row[0] = cell('花枝招展');
+  row[2] = cell(2);
+  row[4] = cell('');
+  row[5] = cell(0);
+  row[6] = cell(0);
+  row[8] = cell('ㄏㄨㄚ ㄓ ㄓㄠ ㄓㄢˇ');
+  row[11] = cell('huā zhī zhāo zhǎn');
+  row[13] = cell('');
+  row[14] = cell('');
+  row[15] = cell(overrides.definitions ?? '形容花木枝葉迎風搖擺。');
+  row[16] = overrides.crossReference === undefined ? empty() : cell(overrides.crossReference);
+
+  const map = {
+    title: 0,
+    term_type: 2,
+    radical: 4,
+    stroke_count: 5,
+    non_radical_stroke_count: 6,
+    bopomofo: 8,
+    pinyin: 11,
+    synonyms: 13,
+    antonyms: 14,
+  } satisfies Record<keyof import('../src/types').ColumnMap, number>;
+  for (const [key, value] of Object.entries(overrides)) {
+    if (key === 'definitions' || key === 'crossReference') continue;
+    row[map[key as keyof typeof map]] = cell(value);
+  }
+  return row;
+}
+```
+
+Replace the old “appends notes block” test and the ctype-0 notes test with:
+
+```ts
+it('ignores modern multi-pronunciation metadata, including internal IDs', () => {
+  const row = modernRow({
+    definitions: '化育萬物的大自然。',
+    crossReference: '(二)ㄗㄠˋ ．ㄏㄨㄚ\n（095030026）',
+  });
+  const { heteronym } = parseHeteronym(row);
+  expect(heteronym.definitions).toEqual([{ def: '化育萬物的大自然。' }]);
+});
+
+it('ignores fullwidth modern multi-pronunciation metadata', () => {
+  const row = modernRow({
+    definitions: '從高處往下看。',
+    crossReference: '（二）ㄌㄧㄣˋ',
+  });
+  const { heteronym } = parseHeteronym(row);
+  expect(heteronym.definitions).toEqual([{ def: '從高處往下看。' }]);
+});
+
+it('preserves legacy editorial notes from column 11', () => {
+  const row: SourceCell[] = new Array(14).fill(null).map(() => empty());
+  row[0] = cell(2);
+  row[2] = cell('舊格式');
+  row[6] = cell('ㄐㄧㄡˋ ㄍㄜˊ ㄕˋ');
+  row[7] = cell('jiù gé shì');
+  row[10] = cell('[名]主義。');
+  row[11] = cell('[動]附義。');
+  const { heteronym } = parseHeteronym(row);
+  expect(heteronym.definitions).toEqual([
+    { def: '主義。', type: '名' },
+    { def: '附義。', type: '動' },
+  ]);
+});
+```
+
+- [ ] **Step 2: Run parser tests and confirm the red state**
+
+Run:
+
+```bash
+bun test tests/parse.test.ts
+```
+
+Expected: the two modern boundary tests FAIL because column 16 still becomes definitions; the legacy test passes and guards behavior that must remain.
+
+- [ ] **Step 3: Remove definition sources from the general column map**
+
+Delete these properties from `ColumnMap` in `src/types.ts`:
+
+```ts
+definitions: number;
+notes: number;
+```
+
+Delete the matching `definitions` and `notes` members from `LEGACY_COLUMNS` and `MODERN_COLUMNS` in `src/parse.ts`.
+
+- [ ] **Step 4: Make the selector the parser's exclusive routing boundary**
+
+Import the selector in `src/parse.ts`:
+
+```ts
+import { definitionSourceColumn } from './excel';
+```
+
+Replace the current definition initialization and notes append path with:
+
+```ts
+const definitionsColumn = definitionSourceColumn(cells.length, 0);
+const editorialColumn = definitionSourceColumn(cells.length, 1);
+const heteronym: Heteronym = {
+  bopomofo: cellText(cells, col.bopomofo),
+  pinyin: cellText(cells, col.pinyin),
+  definitions: parseDefs(cellText(cells, definitionsColumn)),
+};
+
+associateToDefs('synonyms', normalizeText(cellText(cells, col.synonyms)), heteronym.definitions!);
+associateToDefs('antonyms', normalizeText(cellText(cells, col.antonyms)), heteronym.definitions!);
+
+if (editorialColumn >= 0) {
+  const editorialCell = cells[editorialColumn];
+  if (editorialCell && editorialCell.ctype !== 0) {
+    heteronym.definitions!.push(...parseDefs(cellText(cells, editorialColumn)));
+  }
+}
+```
+
+Do not add a fallback path that reads modern column 16.
+
+- [ ] **Step 5: Run focused parser, integration, and type checks**
+
+Run:
+
+```bash
+bun test tests/parse.test.ts tests/integration.test.ts
+bun run typecheck
+bun run verify
+```
+
+Expected: all focused tests PASS; TypeScript exits 0; LemmaScript/Dafny exits 0.
+
+- [ ] **Step 6: Commit parser routing**
+
+```bash
+git add src/types.ts src/parse.ts tests/parse.test.ts
+git commit -m "fix: exclude pronunciation metadata from definitions"
+```
+
+---
+
+### Task 3: Full-workbook semantic verification and cleanup
+
+**Files:**
+- Modify if findings require clarification: `docs/superpowers/specs/2026-07-11-definition-source-invariants-design.md`
+- No permanent comparison script; use `/tmp` artifacts so repository code remains focused.
+
+**Interfaces:**
+- Consumes: the current official workbook, a baseline JSON generated before Task 2, and a fixed JSON generated after Task 2.
+- Produces: evidence that all changed entries are explained by removal of column-16 metadata, including any different heteronym survivor selected by `dedupeHeteronyms`.
+
+- [ ] **Step 1: Generate the fixed full-workbook output**
+
+Using the same workbook and source directory used for the baseline investigation, run:
+
+```bash
+MOEDICT_SOURCE_DIR=/tmp/issue100-source \
+MOEDICT_OUTPUT=/tmp/issue100-dict-revised-fixed.json \
+bun run parse
+```
+
+Expected: 163,920 rows parse into 161,194 entries and the fixed JSON is written.
+
+- [ ] **Step 2: Compare every changed entry semantically**
+
+Use a one-off JavaScript comparison over `/tmp/issue100-dict-revised.json` and `/tmp/issue100-dict-revised-fixed.json` with this logic:
+
+```js
+const fs = await import('node:fs/promises');
+const before = JSON.parse(await fs.readFile('/tmp/issue100-dict-revised.json', 'utf8'));
+const after = JSON.parse(await fs.readFile('/tmp/issue100-dict-revised-fixed.json', 'utf8'));
+const byTitle = (entries) => new Map(entries.map((entry) => [entry.title, entry]));
+const beforeByTitle = byTitle(before);
+const afterByTitle = byTitle(after);
+const changed = [];
+for (const [title, oldEntry] of beforeByTitle) {
+  const newEntry = afterByTitle.get(title);
+  if (JSON.stringify(oldEntry) !== JSON.stringify(newEntry)) {
+    changed.push({ title, before: oldEntry, after: newEntry });
+  }
+}
+const marker = /^（\d+）$|^（[一二三四五六七八九十]）[˙ˇˊˋㄅ-ㄩㄚ-ㄦ]/u;
+const stripMarkers = (entry) => ({
+  ...entry,
+  heteronyms: entry.heteronyms.map((heteronym) => ({
+    ...heteronym,
+    definitions: heteronym.definitions?.filter((definition) => !marker.test(definition.def)),
+  })),
+});
+const unexplained = changed.filter(({ before: oldEntry, after: newEntry }) =>
+  JSON.stringify(stripMarkers(oldEntry)) !== JSON.stringify(newEntry),
+);
+console.log(JSON.stringify({ changed: changed.length, unexplained }, null, 2));
+if (unexplained.length > 0) process.exitCode = 1;
+```
+
+Expected first pass: report every changed title and explicitly expose any non-marker differences caused by `dedupeHeteronyms`; do not assume `unexplained` is empty.
+
+If `unexplained` is non-empty, inspect each complete before/after entry. Classify it as intended only when the surviving heteronym differs solely because the removed cross-reference metadata previously made a duplicate serialize longer; otherwise stop and revise the routing design or dedupe ordering. Record the final count and characterization in the implementation summary.
+
+- [ ] **Step 3: Assert zero leaked metadata after the fix**
+
+Scan every fixed definition with both known patterns:
+
+```js
+const leaked = [];
+for (const entry of after) {
+  for (const heteronym of entry.heteronyms ?? []) {
+    for (const definition of heteronym.definitions ?? []) {
+      if (marker.test(definition.def)) leaked.push({ title: entry.title, def: definition.def });
+    }
+  }
+}
+console.log({ leakedDefinitions: leaked.length, leaked });
+if (leaked.length > 0) process.exitCode = 1;
+```
+
+Expected: `leakedDefinitions: 0`.
+
+- [ ] **Step 4: Run final focused verification**
+
+Run:
+
+```bash
+bun test tests/excel.test.ts tests/parse.test.ts tests/integration.test.ts
+bun run typecheck
+bun run verify
+```
+
+Expected: all selected tests pass with zero failures; TypeScript exits 0; LemmaScript/Dafny exits 0.
+
+- [ ] **Step 5: Commit the amended spec and implementation plan**
+
+```bash
+git add docs/superpowers/specs/2026-07-11-definition-source-invariants-design.md \
+  docs/superpowers/plans/2026-07-11-definition-source-invariants.md
+git commit -m "docs: plan verified definition routing"
+```

--- a/docs/superpowers/specs/2026-07-11-definition-source-invariants-design.md
+++ b/docs/superpowers/specs/2026-07-11-definition-source-invariants-design.md
@@ -27,6 +27,7 @@ The `-1` sentinel means that the source is absent. The helper also proves explic
 ## LemmaScript properties
 
 The selector will carry verified preconditions and postconditions equivalent to:
+The TypeScript parameter is `source: number`, constrained by the LemmaScript precondition, rather than the numeric-literal union `0 | 1`; the current LemmaScript backend does not lower numeric-literal unions reliably.
 
 ```text
 requires rowLength >= 0
@@ -39,12 +40,14 @@ rowLength < 18 && source == 1 ==> result == 11
 rowLength >= 18 ==> result != 16
 ```
 
-These properties establish the source-provenance invariant for every `parseDefs` call made by `parseHeteronym`:
+These properties establish the selector mapping:
 
 ```text
-modern definitions originate only from column 15
-legacy definitions originate only from columns 10 or 11
+modern source slots resolve only to column 15 or absence
+legacy source slots resolve only to columns 10 or 11
 ```
+
+`parseHeteronym` and `parseDefs` remain outside LemmaScript's verified subset because they use regexes and object assembly. Code structure makes the selector their exclusive definition-source router; focused behavioral tests establish that `parseHeteronym` consumes that mapping without bypassing it.
 
 The proof deliberately does not classify strings such as `（digits）`. Marker exclusion would prove a symptom and could reject legitimate text while allowing future metadata formats to leak.
 
@@ -65,7 +68,8 @@ Focused tests will establish:
 3. Exact `造化`-shaped modern rows do not emit internal IDs.
 4. Fullwidth multi-pronunciation metadata does not become a definition.
 5. The real current workbook produces zero definitions matching the known leaked metadata shapes after parsing.
-6. `bun run verify` proves the selector contracts.
+6. A before/after full-workbook semantic diff characterizes every changed entry, including any heteronym selected differently because metadata removal happens before `dedupeHeteronyms`.
+7. `bun run verify` proves the selector contracts.
 
 ## Non-goals
 

--- a/docs/superpowers/specs/2026-07-11-id-aware-taiwanese-xrefs-design.md
+++ b/docs/superpowers/specs/2026-07-11-id-aware-taiwanese-xrefs-design.md
@@ -1,0 +1,106 @@
+# ID-aware Taiwanese Cross-references
+
+## Problem
+
+`src/pack/xref.ts` reads `x-華語對照表.csv` but discards column 2, `詞條編號`, before generating reverse Taiwanese-to-Mandarin cross-references. The generated `t/xref.json` groups only by Taiwanese title and comma-encodes all Mandarin targets. Polyphonic titles therefore lose the association between a target word and its Taiwanese heteronym.
+
+For `照`, the source distinguishes heteronyms `9746` and `9747`, but the current output flattens their reverse mappings to `"依照,按照,,證照"`. No consumer can reconstruct the reading association reliably after this loss.
+
+## Decision
+
+Treat every accepted TWBLG correspondence as the semantic triple:
+
+```text
+(mandarin, taiwaneseTitle, heteronymId)
+```
+
+The forward Mandarin-to-Taiwanese map retains its legacy string format and deduplicates by `(mandarin, taiwaneseTitle)`. The reverse Taiwanese-to-Mandarin map makes a clean cutover to explicit records grouped by Taiwanese title:
+
+```json
+{
+  "a": {
+    "照": [
+      { "id": "9746", "word": "依照" },
+      { "id": "9746", "word": "按照" },
+      { "id": "9747", "word": "照" },
+      { "id": "9746", "word": "證照" }
+    ]
+  }
+}
+```
+
+Reverse records deduplicate by the complete triple and preserve first-source order. Identity correspondences remain explicit words rather than the legacy empty-string sentinel. This representation lets consumers group or render records by heteronym ID without semantic inference.
+
+## Directional deduplication
+
+Forward and reverse projections have different identities and must execute independently:
+
+- forward identity: `(mandarin, taiwaneseTitle)`
+- reverse identity: `(taiwaneseTitle, heteronymId, mandarin)`
+
+The current early `continue` based on the forward map must not suppress reverse insertion. A Mandarin term may legitimately map to two heteronyms sharing one Taiwanese title; forward output should contain the title once while reverse output must retain both IDs.
+
+Exact duplicate triples collapse. Records with the same title and word but different IDs remain distinct.
+
+## LemmaScript boundary
+
+A verified unit models an accepted correspondence triple and its reverse projection. LemmaScript proves the information-preserving scalar relationships that are within its verified subset:
+
+```text
+accepted(mandarin, taiwaneseTitle, heteronymId)
+  requires all three strings are non-empty
+
+reverseId(accepted) == heteronymId
+reverseWord(accepted) == mandarin
+```
+
+The TypeScript grouping loop is structured around this verified projection so no reverse record can be emitted without passing through it.
+
+The collection-level invariant is:
+
+```text
+flatten(reverseGroups) == dedupe(acceptedTriples)
+```
+
+with reverse group identity `(taiwaneseTitle, heteronymId)`. LemmaScript proves the per-triple projection; focused behavioral tests prove grouping, order, complete-triple deduplication, and flattening over collections. CSV decoding, Mandarin-title membership, the existing digit filter, canonical JSON serialization, and filesystem output remain trusted runtime boundaries.
+
+The verified helper must not allocate temporary provenance containers beyond the reverse record required by the output contract. It must preserve the input string values exactly; normalization is not introduced.
+
+## Input acceptance
+
+A TWBLG row is accepted only when:
+
+- Mandarin title, heteronym ID, and Taiwanese title are non-empty;
+- the Mandarin title exists in the supplied Mandarin title set;
+- the Taiwanese title passes the existing digit exclusion.
+
+Malformed or ineligible rows remain omitted. No new normalization or CSV dialect change is part of this work.
+
+## Output compatibility
+
+`t/xref.json` is intentionally a breaking schema change from `Record<string, string>` to `Record<string, Array<{ id: string; word: string }>>` inside its `a` section.
+
+`a/xref.json` retains its existing Taiwanese forward-map format, including empty-string identity components, because that direction does not select a Taiwanese heteronym. Hakka xref generation and output remain unchanged.
+
+## Verification
+
+Focused tests establish:
+
+1. CSV column 2 survives as every reverse record's `id`.
+2. Two rows for one Taiwanese title with different IDs remain distinct.
+3. A duplicated `(mandarin, taiwaneseTitle)` forward relation does not suppress a distinct reverse ID relation.
+4. Exact duplicate triples collapse while preserving first-source order.
+5. Identity rows emit their Mandarin word explicitly in reverse output.
+6. Flattening reverse groups reproduces the accepted triples after complete-triple deduplication.
+7. Existing Mandarin-to-Taiwanese bytes remain unchanged for equivalent fixtures.
+8. Hakka output remains unchanged.
+9. `bun run verify` proves the scalar projection contracts.
+10. The focused xref test suite and typecheck pass.
+
+## Non-goals
+
+- Changing the Mandarin-to-Taiwanese xref schema.
+- Changing Hakka cross-references.
+- Updating web consumers in this repository change.
+- Inferring heteronym IDs from titles, readings, or definitions.
+- Adding compatibility sidecars, aliases, or dual reverse representations.

--- a/docs/superpowers/specs/2026-07-11-id-aware-taiwanese-xrefs-design.md
+++ b/docs/superpowers/specs/2026-07-11-id-aware-taiwanese-xrefs-design.md
@@ -14,22 +14,20 @@ Treat every accepted TWBLG correspondence as the semantic triple:
 (mandarin, taiwaneseTitle, heteronymId)
 ```
 
-The forward Mandarin-to-Taiwanese map retains its legacy string format and deduplicates by `(mandarin, taiwaneseTitle)`. The reverse Taiwanese-to-Mandarin map makes a clean cutover to explicit records grouped by Taiwanese title:
+The existing `a/xref.json` and `t/xref.json` string maps are frozen downstream contracts: the live legacy `moedict.org` frontend reads reverse values as comma-delimited strings. They therefore remain byte-compatible. A new `t/xref-by-id.json` sidecar is generated from the same accepted rows and groups Mandarin words by Taiwanese title and heteronym ID:
 
 ```json
 {
   "a": {
-    "照": [
-      { "id": "9746", "word": "依照" },
-      { "id": "9746", "word": "按照" },
-      { "id": "9747", "word": "照" },
-      { "id": "9746", "word": "證照" }
-    ]
+    "照": {
+      "9746": ["依照", "按照", "證照"],
+      "9747": ["照"]
+    }
   }
 }
 ```
 
-Reverse records deduplicate by the complete triple and preserve first-source order. Identity correspondences remain explicit words rather than the legacy empty-string sentinel. This representation lets consumers group or render records by heteronym ID without semantic inference.
+Sidecar words deduplicate by the complete triple and preserve first-source order. Identity correspondences remain explicit words rather than the legacy empty-string sentinel. The legacy maps and sidecar share one row loop, preventing independent pipelines from drifting.
 
 ## Directional deduplication
 
@@ -64,7 +62,7 @@ flatten(reverseGroups) == dedupe(acceptedTriples)
 
 with reverse group identity `(taiwaneseTitle, heteronymId)`. LemmaScript proves the per-triple projection; focused behavioral tests prove grouping, order, complete-triple deduplication, and flattening over collections. CSV decoding, Mandarin-title membership, the existing digit filter, canonical JSON serialization, and filesystem output remain trusted runtime boundaries.
 
-The verified helper must not allocate temporary provenance containers beyond the reverse record required by the output contract. It must preserve the input string values exactly; normalization is not introduced.
+The verified helpers return their input strings directly and allocate nothing. Group arrays are the required sidecar output; no temporary provenance objects or normalization are introduced.
 
 ## Input acceptance
 
@@ -78,19 +76,19 @@ Malformed or ineligible rows remain omitted. No new normalization or CSV dialect
 
 ## Output compatibility
 
-`t/xref.json` is intentionally a breaking schema change from `Record<string, string>` to `Record<string, Array<{ id: string; word: string }>>` inside its `a` section.
+`t/xref.json` remains `Record<string, string>` because `moedict.org`, `moedict.tw`, and the app consume that path. Its comma encoding and empty identity sentinel are unchanged.
 
-`a/xref.json` retains its existing Taiwanese forward-map format, including empty-string identity components, because that direction does not select a Taiwanese heteronym. Hakka xref generation and output remain unchanged.
+`t/xref-by-id.json` adds an `a` section shaped as `Record<taiwaneseTitle, Record<heteronymId, string[]>>`. `a/xref.json` and Hakka output remain unchanged.
 
 ## Verification
 
 Focused tests establish:
 
-1. CSV column 2 survives as every reverse record's `id`.
+1. CSV column 2 survives as each sidecar group key.
 2. Two rows for one Taiwanese title with different IDs remain distinct.
-3. A duplicated `(mandarin, taiwaneseTitle)` forward relation does not suppress a distinct reverse ID relation.
+3. A duplicated `(mandarin, taiwaneseTitle)` legacy relation does not suppress a distinct sidecar ID relation.
 4. Exact duplicate triples collapse while preserving first-source order.
-5. Identity rows emit their Mandarin word explicitly in reverse output.
+5. Identity rows emit their Mandarin word explicitly in the sidecar while legacy output retains its empty sentinel.
 6. Flattening reverse groups reproduces the accepted triples after complete-triple deduplication.
 7. Existing Mandarin-to-Taiwanese bytes remain unchanged for equivalent fixtures.
 8. Hakka output remains unchanged.
@@ -103,4 +101,4 @@ Focused tests establish:
 - Changing Hakka cross-references.
 - Updating web consumers in this repository change.
 - Inferring heteronym IDs from titles, readings, or definitions.
-- Adding compatibility sidecars, aliases, or dual reverse representations.
+- Replacing or aliasing either legacy `xref.json` representation.

--- a/src/pack/xref.ts
+++ b/src/pack/xref.ts
@@ -6,6 +6,21 @@ import { codepointCount } from './codepoint';
 import { canonicalJson } from './serializer';
 
 type StringMap = Record<string, string>;
+type ReverseXrefById = Record<string, Record<string, string[]>>;
+
+export function reverseXrefId(heteronymId: string): string {
+  //@ verify
+  //@ requires heteronymId.length > 0
+  //@ ensures \result === heteronymId
+  return heteronymId;
+}
+
+export function reverseXrefWord(mandarin: string): string {
+  //@ verify
+  //@ requires mandarin.length > 0
+  //@ ensures \result === mandarin
+  return mandarin;
+}
 
 function append(map: StringMap, key: string, value: string): void {
   map[key] = map[key] === undefined ? value : `${map[key]},${value}`;
@@ -77,19 +92,35 @@ export function writeXrefs(
   if (fs.existsSync(twblgPath)) {
     const aToT: StringMap = {};
     const tToA: StringMap = {};
+    const tToAById: ReverseXrefById = {};
     append(aToT, '萌', '發穎');
     append(tToA, '發穎', '萌');
     for (const row of fs.readFileSync(twblgPath, 'utf8').replace(/^\uFEFF/, '').split('\n').slice(1)) {
-      const [mandarin, , taiwanese] = row.replace(/\r$/, '').split(',', 3);
-      if (!mandarin || taiwanese === undefined || !mandarinTitles.has(mandarin) || /\d/.test(taiwanese)) continue;
+      const [mandarin, heteronymId, taiwanese] = row.replace(/\r$/, '').split(',', 3);
+      if (
+        !mandarin ||
+        !heteronymId ||
+        !taiwanese ||
+        !mandarinTitles.has(mandarin) ||
+        /\d/.test(taiwanese)
+      ) continue;
+
+      const id = reverseXrefId(heteronymId);
+      const word = reverseXrefWord(mandarin);
+      const byId = tToAById[taiwanese] ?? (tToAById[taiwanese] = {});
+      const words = byId[id] ?? (byId[id] = []);
+      if (!words.includes(word)) words.push(word);
+
       const forward = taiwanese === mandarin ? '' : taiwanese;
       const reverse = taiwanese === mandarin ? '' : mandarin;
-      if (aToT[mandarin]?.split(',').includes(forward)) continue;
-      append(aToT, mandarin, forward);
-      append(tToA, taiwanese, reverse);
+      if (!aToT[mandarin]?.split(',').includes(forward)) {
+        append(aToT, mandarin, forward);
+        append(tToA, taiwanese, reverse);
+      }
     }
     a.t = aToT;
     writeJson(outputDir, 't', 'xref.json', { a: tToA });
+    writeJson(outputDir, 't', 'xref-by-id.json', { a: tToAById });
   }
 
   const hakkaPath = path.join(inputDir, 'work-in-progress.json');

--- a/tests/pack/xref.test.ts
+++ b/tests/pack/xref.test.ts
@@ -27,16 +27,37 @@ describe('writeXrefs', () => {
     expect(fs.existsSync(path.join(out, 'a', 'xref.json'))).toBe(false);
   });
 
-  it('writes Taiwanese sectioned mappings with identity empty components', () => {
+  it('preserves Taiwanese heteronym IDs independently of forward deduplication', () => {
     fs.writeFileSync(
       path.join(input, 'x-華語對照表.csv'),
-      '華語,詞條編號,詞條名稱\n同僚,2,同事\n同僚,3,同僚\n不存在,4,無\n',
+      [
+        '華語,詞條編號,詞條名稱',
+        '依照,9746,照',
+        '按照,9746,照',
+        '照,9747,照',
+        '證照,9746,照',
+        '照,9746,照',
+        '依照,9746,照',
+        '',
+      ].join('\n'),
     );
-    writeXrefs(input, out, new Set(['同僚']));
-    expect(readJson(out, 'a/xref.json')).toEqual({ t: { 同僚: '同事,', 萌: '發穎' } });
-    expect(readJson(out, 't/xref.json')).toEqual({ a: { 同事: '同僚', 同僚: '', 發穎: '萌' } });
+    writeXrefs(input, out, new Set(['依照', '按照', '照', '證照']));
+    expect(readJson(out, 'a/xref.json')).toEqual({
+      t: { 依照: '照', 按照: '照', 照: '', 證照: '照', 萌: '發穎' },
+    });
+    expect(readJson(out, 't/xref.json')).toEqual({
+      a: { 照: '依照,按照,,證照', 發穎: '萌' },
+    });
+    expect(readJson(out, 't/xref-by-id.json')).toEqual({
+      a: {
+        照: {
+          '9746': ['依照', '按照', '證照', '照'],
+          '9747': ['照'],
+        },
+      },
+    });
     expect(fs.readFileSync(path.join(out, 'a', 'xref.json'), 'utf8')).toBe(
-      '{"t":{"同僚":"同事,","萌":"發穎"}}\n',
+      '{"t":{"依照":"照","按照":"照","照":"","萌":"發穎","證照":"照"}}\n',
     );
   });
 


### PR DESCRIPTION
## Problem

`src/pack/xref.ts` discarded CSV column 2 (`詞條編號`) before generating reverse Taiwanese-to-Mandarin cross-references. The generated `t/xref.json` grouped only by Taiwanese title and comma-encoded all Mandarin targets. Polyphonic titles lost the association between a target word and its Taiwanese heteronym.

For `照`, the source distinguishes heteronyms `9746` and `9747`, but the current output flattened their reverse mappings to `"依照,按照,,證照"`. No consumer could reconstruct the reading association reliably after this loss.

See [g0v/moedict-webkit#23](https://github.com/g0v/moedict-webkit/issues/23).

## Change

Treat every accepted TWBLG correspondence as the semantic triple `(mandarin, taiwaneseTitle, heteronymId)`.

- **Legacy `a/xref.json`, `t/xref.json`, Hakka xrefs**: unchanged — frozen downstream contracts consumed by `moedict.tw`, `moedict-app`, and the live `moedict.org` frontend.
- **New `t/xref-by-id.json` sidecar**: generated from the same accepted CSV-row loop, groups Mandarin words by Taiwanese title and heteronym ID:

```json
{
  "a": {
    "照": {
      "9746": ["依照", "按照", "證照"],
      "9747": ["照"]
    }
  }
}
```

Identity correspondences are explicit words in the sidecar, not the legacy empty-string sentinel.

### Directional deduplication

- Forward/reverse legacy identity: `(mandarin, taiwaneseTitle)`
- Sidecar identity: `(taiwaneseTitle, heteronymId, mandarin)`

The early forward-map `continue` was removed so a Mandarin term legitimately mapped to two readings of the same Taiwanese title retains both ID associations in the sidecar.

### LemmaScript

Added `src/pack/xref.ts` to `LemmaScript-files.txt`. Two verified identity helpers prove the heteronym ID and Mandarin word cannot be rewritten or discarded during reverse projection:

```text
reverseXrefId(heteronymId) == heteronymId
reverseXrefWord(mandarin) == mandarin
```

Collection invariant `flatten(reverseGroups) == dedupe(acceptedTriples)` with group identity `(taiwaneseTitle, heteronymId)` is covered by focused behavioral tests.

## Verification

- `bun test tests/pack` — 68 pass, 4 skip, 0 fail
- `bun run verify` — all LemmaScript/Dafny modules verified, 0 errors
- `bun run typecheck` — `tsc -b --noEmit`, exit 0

## Downstream

Frontend consumer work (rendering xref groups beside matching heteronyms) will follow in `g0v/moedict.tw`. This PR is process-side only.